### PR TITLE
Adding symlinks to model_path to avoid OsError36

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ python launch_eval.py \
 --hf_home $HF_HOME \
 --venv_path $VENV_DIR  \
 --eval_output_path ~/evals/ \
---symlink_path ~/tmp
+--symlink_path ~/evals/model-symlink/
 ```
 
 You can alternatively pass `--model_file models.txt` instead of `--model`. The provided file should contain one path

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ python launch_eval.py \
 --hf_home $HF_HOME \
 --venv_path $VENV_DIR  \
 --eval_output_path ~/evals/ \
+--symlink_path ~/tmp
 ```
 
 You can alternatively pass `--model_file models.txt` instead of `--model`. The provided file should contain one path

--- a/llmeval/launch_eval.py
+++ b/llmeval/launch_eval.py
@@ -67,6 +67,12 @@ def main():
         required=True,
     )
     parser.add_argument(
+        "--symlink_path",
+        type=str,
+        help="location where to store symlinks for models to evaluate",
+        required=True,
+    )
+    parser.add_argument(
         "--max_jobs",
         type=int,
         help="maximum number of jobs to launch",
@@ -91,6 +97,7 @@ def main():
     hf_home = args.hf_home
     venv_path = args.venv_path
     eval_output_path = args.eval_output_path
+    symlink_path = args.symlink_path
     jobname = "openeurollm/eval"
 
     n_fewshot_to_tasks = load_tasks_from_path(Path(__file__).parent / "tasks.txt")
@@ -122,6 +129,7 @@ def main():
 source {venv_path}/bin/activate
 export HF_HOME={hf_home}
 export LM_EVAL_OUTPUT_PATH={eval_output_path}
+export SYMLINK_PATH={symlink_path}
 # export CUDA_VISIBLE_DEVICES=0,1,2,3  # number of GPU specific
     """
     if args.start:

--- a/llmeval/launch_eval.py
+++ b/llmeval/launch_eval.py
@@ -69,8 +69,8 @@ def main():
     parser.add_argument(
         "--symlink_path",
         type=str,
-        help="location where to store symlinks for models to evaluate",
-        required=True,
+        help="location where to store symlinks for models to be evaluated",
+        required=False,
     )
     parser.add_argument(
         "--max_jobs",
@@ -129,9 +129,10 @@ def main():
 source {venv_path}/bin/activate
 export HF_HOME={hf_home}
 export LM_EVAL_OUTPUT_PATH={eval_output_path}
-export SYMLINK_PATH={symlink_path}
 # export CUDA_VISIBLE_DEVICES=0,1,2,3  # number of GPU specific
     """
+    if symlink_path:
+      bash_setup_command += f"\nexport SYMLINK_PATH={symlink_path}"
     if args.start:
         python_args = python_args[args.start:]
     if args.max_jobs is not None:

--- a/llmeval/setup_node.sh
+++ b/llmeval/setup_node.sh
@@ -36,7 +36,7 @@ fi
 
 echo -e "${RED}Download datasets${NC}"
 mkdir -p $HF_HOME
-TASKS="commonsense_qa,piqa,winogrande,arc_challenge,arc_easy,mmlu,mmlu_continuation,hellaswag,copa,openbookqa,lambada_openai,winogrande,boolq,mmlu_pro"
+TASKS="commonsense_qa,pqa,winogrande,arc_challenge,arc_easy,mmlu,mmlui_continuation,hellaswag,copa,openbookqa,lambada_openai,winogrande,boolq,mmlu_pro,social_iqa"
 
 # Run a tiny model on all datasets to make sure they are all available locally
 # A cleaner approach would to download the dataset directly


### PR DESCRIPTION
## Current issue

We currently launch evals with:

```bash
accelerate launch -m lm_eval -model hf \
    --model_args pretrained=$MODEL_PATH\
    --output_path /leonardo_scratch/large/userexternal/$USER/oellm_evals/$SLURM_ARRAY_JOB_ID/$MODEL_STR/$TASK_STR
```
where `$MODEL_STR` is a truncated `$MODEL_PATH`.


However:
1. lm_eval already uses `$MODEL_PATH` internally to create a results' folder.
2. MODEL_PATH is too long, triggering OSError36: Filename Too Long, and not saving results

## Fix

Just passing `output_path=/leonardo_scratch/large/userexternal/$USER/oellm_evals` without $MODEL_STR still triggers OsError36.

Hence, we create symlink at a shorter path, pointing to the original MODEL_PATH, and eval the model using the symlinks:

```bash
MODEL_SYMLINK="$SYMLINK_PATH/$(openssl rand -hex 4)"
mkdir -p "$(dirname "$MODEL_SYMLINK")"
ln -sfn "$MODEL_PATH" "$MODEL_SYMLINK"
accelerate launch -m lm_eval --model hf \
    --model_args pretrained=$MODEL_SYMLINK \
    --output_path $OUTPUT_PATH
```