### PR TITLE
remove symlink, output_path fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ python launch_eval.py \
 --account XXX \
 --hf_home $HF_HOME \
 --venv_path $VENV_DIR  \
---eval_output_path ~/evals/ \
---symlink_path ~/evals/model-symlink/
+--eval_output_path ~/evals/
 ```
 
 You can alternatively pass `--model_file models.txt` instead of `--model`. The provided file should contain one path

--- a/llmeval/main_script.sh
+++ b/llmeval/main_script.sh
@@ -49,19 +49,10 @@ if [ -d $MODEL_PATH_OR_NAME ]; then
     WANDB_NAME="$SLURM_ARRAY_JOB_ID-$MODEL_STR"
     echo "Evaluate $MODEL_PATH"
 
-    # if SYMLINK_PATH is set, make a short link and override MODEL_PATH
-    if [ -n "${SYMLINK_PATH:-}" ]; then
-      mkdir -p "$SYMLINK_PATH"
-      LINK="$SYMLINK_PATH/$(openssl rand -hex 4)"
-      ln -sfn "$MODEL_PATH" "$LINK"
-      MODEL_PATH="$LINK"
-      echo "Using symlink $MODEL_PATH"
-    fi
-
     accelerate launch -m lm_eval --model hf \
         --model_args pretrained=$MODEL_PATH,trust_remote_code=True\
         --tasks $TASKS \
-        --output_path $OUTPUT_PATH \
+        --output_path $OUTPUT_PATH/$MODEL_STR/${TASK_STR}_${NUM_FEWSHOT}/results.json \
         --batch_size $BATCH_SIZE \
         --num_fewshot $NUM_FEWSHOT \
         --trust_remote_code \
@@ -77,7 +68,7 @@ else
   accelerate launch -m lm_eval --model hf \
     --model_args pretrained=$MODEL_PATH_OR_NAME,trust_remote_code=True\
     --tasks $TASKS \
-    --output_path $OUTPUT_PATH \
+    --output_path $OUTPUT_PATH/$MODEL_STR/${TASK_STR}_${NUM_FEWSHOT}/results.json \
     --batch_size $BATCH_SIZE \
     --num_fewshot $NUM_FEWSHOT \
     --trust_remote_code \


### PR DESCRIPTION
We added symlinks as a patch for a bug in lm-eval-harness.

Commity [178fa84da05dd1050e309f8a9d8bcd67f34f42d6](https://github.com/EleutherAI/lm-evaluation-harness/commit/178fa84da05dd1050e309f8a9d8bcd67f34f42d6) in lm-harness fixed the aformentioned bug, so symlinks are not needed anymore.

Be sure to update lm-eval-harness tho!